### PR TITLE
fix(FilesContainer): further tweaks to files container to enable subf…

### DIFF
--- a/app/extensions/safe/components/FilesContainer/FilesContainer.tsx
+++ b/app/extensions/safe/components/FilesContainer/FilesContainer.tsx
@@ -34,26 +34,20 @@ FilesContainerProps,
             text: string;
         } => {
             // get the base url out of the way
-            let theLink = filesMapPath;
-            if ( filesMapPath.includes( locationWithoutQuery ) ) {
-              theLink = filesMapPath.split( locationWithoutQuery )[1];
+            let theLinkText = filesMapPath;
+
+            // only get the next part of the tree
+            if ( theLinkText.startsWith( '/' ) ) {
+                theLinkText = `/${theLinkText.split( '/' )[1]}`;
+            } else {
+                theLinkText = theLinkText.split( '/' )[0];
             }
 
-            if ( theLink.includes( '/' ) ) {
-                // only get the next part of the tree
-                theLink = theLink.split( '/' )[1];
-            }
-
-            const startLocation = locationWithoutQuery.endsWith( '/' )
-                ? locationWithoutQuery
-                : `${locationWithoutQuery}/`;
-            const href = `${startLocation}${theLink}${
-                version ? `?v=${version}` : ''
-            }`;
+            const href = `${theLinkText}${version ? `?v=${version}` : ''}`;
 
             return {
                 link: href,
-                text: theLink
+                text: theLinkText
             };
         } );
 

--- a/app/extensions/safe/test/components/FilesContainer.spec.tsx
+++ b/app/extensions/safe/test/components/FilesContainer.spec.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+// import configureStore from 'redux-mock-store';
+import { FilesContainer } from '$Extensions/safe/components/FilesContainer';
+
+// const mockStore = configureStore();
+
+jest.mock( '$Logger' );
+
+describe( 'FilesContainer', () => {
+    let wrapper;
+    let instance;
+    let props;
+    // let store;
+
+    beforeEach( () => {
+        props = {
+            filesMap: {
+                '/testfolder/file': {
+                    link: 'safe://lalalalalala'
+                },
+                '/testfolder/subfolder/subfile': {
+                    link: 'safe://lalalalalala'
+                },
+                '/testfolder/subfolder/subfile2': {
+                    link: 'safe://lalalalalala'
+                },
+                '/testfolder/subfolder/subsub/subsubfile': {
+                    link: 'safe://lalalalalala'
+                },
+                '/anotherfolder/somefile': {
+                    link: 'safe://lalalalalala'
+                }
+            },
+            currentLocation: 'safe://nowhere'
+        };
+
+        wrapper = shallow( <FilesContainer {...props} /> );
+        instance = wrapper.instance();
+    } );
+
+    describe( 'constructor( props )', () => {
+        beforeEach( () => {
+            // store = mockStore( props );
+        } );
+
+        it( 'should have name FilesContainer', () => {
+            expect( instance.constructor.name ).toMatch( 'FilesContainer' );
+        } );
+    } );
+
+    describe( 'files subfolder display', () => {
+        it( 'should display only one list', () => {
+            expect( wrapper.find( 'ul' ).length ).toBe( 1 );
+        } );
+
+        it( 'should display only next level folders / files once', () => {
+            expect( wrapper.find( 'li' ).length ).toBe( 2 );
+            expect(
+                wrapper
+                    .find( 'a' )
+                    .first()
+                    .props()
+            ).toMatchObject( { children: '/testfolder', href: '/testfolder' } );
+            expect(
+                wrapper
+                    .find( 'a' )
+                    .last()
+                    .props()
+            ).toMatchObject( { children: '/anotherfolder', href: '/anotherfolder' } );
+        } );
+
+        it( 'should display only next level folders / files, when already at a location', () => {
+            const newProps = {
+                filesMap: {
+                    'subfolder/subfile': {
+                        link: 'safe://lalalalalala'
+                    },
+                    'subfolder/subfile2': {
+                        link: 'safe://lalalalalala'
+                    },
+                    'subfolder2/subsub/subsubfile': {
+                        link: 'safe://lalalalalala'
+                    },
+                    'subfolder2/subsub/subsubfile2': {
+                        link: 'safe://lalalalalala'
+                    }
+                },
+                currentLocation: 'safe://nowhere/testfolder'
+            };
+            wrapper = shallow( <FilesContainer {...newProps} /> );
+
+            expect( wrapper.find( 'li' ).length ).toBe( 2 );
+            expect(
+                wrapper
+                    .find( 'a' )
+                    .first()
+                    .props()
+            ).toMatchObject( { href: 'subfolder' } );
+            expect(
+                wrapper
+                    .find( 'a' )
+                    .last()
+                    .props()
+            ).toMatchObject( { href: 'subfolder2' } );
+        } );
+    } );
+} );


### PR DESCRIPTION
…older rendering

Adds tests too

<!--
#### Thank you for contributing!

Please reference the issue(s) which this pull request addresses using [keywords](https://help.github.com/articles/closing-issues-using-keywords/) such as:

```
Resolves #452
Fixes #363
Closes #408
```

---

Provide QA team and reviewer steps to test the resolution.
For example:

```
QA:
Easiest way to test this PR would be to:
- Run API playground
- Initialise app
- Copy the value from [authReqWithoutMockBit](https://github.com/maidsafe/safe_browser/compare/master...hunterlester:454?expand=1#diff-a003f29f7e2f9aeecfe6e3fbb39e3d2eR30)
- Paste value into `authorise` operation and run
- Expect to see an error notification
- Same steps for [encodedNonExistentShareMDataReq](https://github.com/maidsafe/safe_browser/compare/master...hunterlester:454?expand=1#diff-a003f29f7e2f9aeecfe6e3fbb39e3d2eR28)

To QA with external app:
- You could use my repo and [set `forceUseMock` to `false` here](https://github.com/hunterlester/safe-app-base/blob/master/renderer.js#L58), in order to get a `-208` error.
- To test for error `-103`, uncomment [this block](https://github.com/hunterlester/safe-app-base/blob/master/renderer.js#L60-L68), then replace [authUri here](https://github.com/hunterlester/safe-app-base/blob/master/renderer.js#L69), with the `shareMDataReqUri` variable.
```

---

Commit messages should conform to the format:

```
<type>(<scope>): <description>

[optional body]

```

For example:

```
fix(auth): proper values returned on auth_decode_ipc_msg errors

  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share MData
    request for non-existent MData

```

Commit `type` can be one of:  
**feat**: New feature  
**fix**: Bug fix  
**docs**: Documentation only changes  
**style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)  
**refactor**: A code change that neither fixes a bug nor adds a feature  
**perf**: A code change that improves performance  
**test**: Adding missing tests  
**chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation  
**revert**: Reverting a feature, fix, or commit which introduces a regression or new bug

Commit `scope` is open to any succinct term which indicates the effected feature or component.

See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)

---
Write your description below this line: -->
